### PR TITLE
example of fixtures

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,9 @@
+"""General parameters for tests."""
+import pathlib
+
+
+rootdir = pathlib.Path(".")
+datadir = rootdir / "tests" / "data"
+
+defaultmdl = str(datadir / 'pdb' / 'default.pdb')
+multimodel = str(datadir / 'pdb' / 'multimodel.pdb')

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -36,6 +36,8 @@ from interfacea.core.structure import (
 )
 import interfacea.exceptions as e
 
+from . import defaultmdl
+
 
 def test_dummy_structure():
     """Successfully creates a small structure from Atoms"""
@@ -205,27 +207,45 @@ class TestStructure:
         with pytest.raises(KeyError):
             da.select('Z')
 
+    @pytest.fixture(params=[defaultmdl])
+    def structure_from_defaultmdl(self, request):
+        """Read a structure from defaultmdl"""
+        s = read_structure(request.param)
+        return s
+
     # class Structure
-    def test_Structure_io_read(self):
-        """io.read() successfully builds Structure"""
+    #def test_Structure_io_read(self):
+    #    """io.read() successfully builds Structure"""
+    #    s = read_structure(self.defaultmdl)  # io.read()
+    
+    def test_structure_defaultmdl_name(self, structure_from_defaultmdl):
+        print(type(structure_from_defaultmdl))
+        assert structure_from_defaultmdl.name == 'default.pdb'
 
-        s = read_structure(self.defaultmdl)  # io.read()
 
-        assert s.name == 'default.pdb'
-        assert s.natoms == 107
-        assert s.nmodels == 1
-        assert s.precision == np.float16
+    def test_structure_defaultmdl_natoms(self, structure_from_defaultmdl):
+        assert structure_from_defaultmdl.natoms == 107
 
+
+    def test_structure_defaultmdl_nmodels(self, structure_from_defaultmdl):
+        assert structure_from_defaultmdl.nmodels == 1
+
+
+    def test_structure_defaultmdl_precision(self, structure_from_defaultmdl):
+        assert structure_from_defaultmdl.precision == np.float16
+
+    
+    def test_structure_defaultmdl_atoms(self, structure_from_defaultmdl):
         # Check DisorderedAtom
         # Check atoms are bound
-        for atom in s.atoms:
+        for atom in structure_from_defaultmdl.atoms:
             if atom.serial == 18:
                 assert isinstance(atom, DisorderedAtom)
                 assert atom.nlocs == 2
             else:
                 assert isinstance(atom, Atom)
 
-            assert atom.parent is s
+            assert atom.parent is structure_from_defaultmdl
 
     def test_Structure_io_read_noaltlocs(self):
         """io.read() successfully builds Structure (no altloc)"""


### PR DESCRIPTION
Without going too deep into the matter, I just want to provide an example of `fixtures` so that you can separate the `assert` statements in different test functions.

You can see that I transferred the file paths variables to the module level inside the `__init__.py` i found this a better practice because you can use them test-wide and this also provides a much easier implementation of the `fixtures`.

I have not cleaned the `pre-commit` hook messages. But tests pass. Is just an example for you to consider.

I am also not so proficient with `fixtures` maybe a more experienced developer with `pytest` can provide a better solution, though I find this one very simple.